### PR TITLE
This change adds the SymbioticTS.Build project along with other supporting fixes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,8 @@
   <PropertyGroup>
     <!-- https://github.com/Microsoft/msbuild/issues/1298 -->
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+
+    <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,6 +22,7 @@
 
     <authors>Craig Treasure</authors>
     <owners>craigktreasure</owners>
+    <description>A package supporting SymbioticTS.</description>
     <PackageTags>typescript dotnet dotnetcore aspnetcore</PackageTags>
     <PackageProjectUrl>https://github.com/craigktreasure/SymbioticTS</PackageProjectUrl>
     <RepositoryUrl>https://github.com/craigktreasure/SymbioticTS.git</RepositoryUrl>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project=".\Project.Dependencies.props" />
+
   <PropertyGroup>
     <!-- https://github.com/Microsoft/msbuild/issues/1298 -->
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
@@ -26,10 +28,8 @@
 
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning">
-      <Version>2.2.13</Version>
+      <Version>$(NerdbankGitVersioningVersion)</Version>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-
-  <Import Project=".\Project.Dependencies.props" />
 </Project>

--- a/Example/.gitignore
+++ b/Example/.gitignore
@@ -1,0 +1,1 @@
+generated-ts

--- a/Example/Example.csproj
+++ b/Example/Example.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SymbioticTS.Build" Version="0.1-*" PrivateAssets="All" />
+    <PackageReference Include="SymbioticTS.Abstractions" Version="0.1-*" />
+  </ItemGroup>
+
+</Project>

--- a/Example/Example.sln
+++ b/Example/Example.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Example", "Example.csproj", "{3FE6A702-DF08-4DFF-AD63-2FF6A82C8D73}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3FE6A702-DF08-4DFF-AD63-2FF6A82C8D73}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3FE6A702-DF08-4DFF-AD63-2FF6A82C8D73}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3FE6A702-DF08-4DFF-AD63-2FF6A82C8D73}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3FE6A702-DF08-4DFF-AD63-2FF6A82C8D73}.Debug|x64.Build.0 = Debug|Any CPU
+		{3FE6A702-DF08-4DFF-AD63-2FF6A82C8D73}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3FE6A702-DF08-4DFF-AD63-2FF6A82C8D73}.Debug|x86.Build.0 = Debug|Any CPU
+		{3FE6A702-DF08-4DFF-AD63-2FF6A82C8D73}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3FE6A702-DF08-4DFF-AD63-2FF6A82C8D73}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3FE6A702-DF08-4DFF-AD63-2FF6A82C8D73}.Release|x64.ActiveCfg = Release|Any CPU
+		{3FE6A702-DF08-4DFF-AD63-2FF6A82C8D73}.Release|x64.Build.0 = Release|Any CPU
+		{3FE6A702-DF08-4DFF-AD63-2FF6A82C8D73}.Release|x86.ActiveCfg = Release|Any CPU
+		{3FE6A702-DF08-4DFF-AD63-2FF6A82C8D73}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/Example/Gender.cs
+++ b/Example/Gender.cs
@@ -1,0 +1,8 @@
+namespace Example
+{
+    public enum Gender
+    {
+        Female,
+        Male
+    }
+}

--- a/Example/Person.cs
+++ b/Example/Person.cs
@@ -1,0 +1,19 @@
+using SymbioticTS.Abstractions;
+using System;
+
+namespace Example
+{
+    [TsDto]
+    public class Person
+    {
+        public string FirstName { get; set; }
+
+        public string LastName { get; set; }
+
+        public DateTime BirthDate { get; set; }
+
+        public int Age { get; set; }
+
+        public Gender Gender { get; set; }
+    }
+}

--- a/Example/nuget.config
+++ b/Example/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+ <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="local" value="../__nuget/Release" />
+ </packageSources>
+</configuration>

--- a/Project.Dependencies.props
+++ b/Project.Dependencies.props
@@ -4,5 +4,7 @@
     <NerdbankGitVersioningVersion>2.2.13</NerdbankGitVersioningVersion>
     <MicrosoftNETTestSdkVersion>15.8.0</MicrosoftNETTestSdkVersion>
     <XUnitVersion>2.4.0</XUnitVersion>
+    <MicrosoftBuildFrameworkVersion>15.7.179</MicrosoftBuildFrameworkVersion>
+    <MicrosoftBuildUtilitiesCoreVersion>$(MicrosoftBuildFrameworkVersion)</MicrosoftBuildUtilitiesCoreVersion>
   </PropertyGroup>
  </Project>

--- a/Project.Dependencies.props
+++ b/Project.Dependencies.props
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <NerdbankGitVersioningVersion>2.2.13</NerdbankGitVersioningVersion>
     <MicrosoftNETTestSdkVersion>15.8.0</MicrosoftNETTestSdkVersion>
     <XUnitVersion>2.4.0</XUnitVersion>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # SymbioticTS
 
+## Status: Beta
+
 [![Build Status](https://treasure.visualstudio.com/SymbioticTS/_apis/build/status/craigktreasure.SymbioticTS)](https://treasure.visualstudio.com/SymbioticTS/_build/latest?definitionId=13)
 
-## Status: Planning
-
-This project is not yet "real" and is currently being planned and developed.
+The project is currently in what I would consider early beta status.
 
 ## Goals
 
@@ -32,11 +32,11 @@ As you pass objects to a frontend in json format, you lose some type fidelity. F
 
 ## Workflow
 
-* Add the SymbioticTypeScript.MSBuild NuGet package to a project.
-* Configure output location.
-* Attribute an interface with `TsInterface` or a class with `TsDto` or `TsClass`.
+* Add the SymbioticTS.Build NuGet package to a project.
+* Configure output location using the `SymbioticTSOutputPath` MSBuild property.
+* Attribute a class with `TsDto` or `TsClass` or an interface with `TsInterface`.
 * Build
-  * Discover the full closure of the built assembly dependencies (except for .NET assemblies).
+  * Discovers the full closure of the built assembly dependencies (excluding .NET assemblies).
   * Discover public or internal attributed classes and interfaces.
   * Generate TypeScript objects for attributed and supporting .NET objects.
 
@@ -64,25 +64,19 @@ export interface IRectangleDto
     readonly dateCreated: string;
 }
 
-export class RectangleDto
+export class Rectangle
 {
-    private readonly _dateCreated: Date;
-
-    public get dateCreated(): Date {
-        return this._dateCreated;
-    }
+    public readonly dateCreated: Date;
 
     constructor(public x: number, public y: number, dateCreated: Date) {
-        this._dateCreated = dateCreated;
+        this.dateCreated = dateCreated;
     }
 
     public static fromDto(dto: IRectangleDto): Rectangle
     {
-        const x = dto.x;
-        const y = dto.y;
         const dateCreated = new Date(Date.parse(dto.dateCreated))
 
-        return new Rectangle(x, y, dateCreated);
+        return new Rectangle(dto.x, dto.y, dateCreated);
     }
 }
 ```

--- a/SymbioticTS.Abstractions/SymbioticTS.Abstractions.csproj
+++ b/SymbioticTS.Abstractions/SymbioticTS.Abstractions.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
 
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+
+    <description>Provides the SymbioticTS abstractions.</description>
   </PropertyGroup>
 
 </Project>

--- a/SymbioticTS.Build/SymbioticTS.Build.csproj
+++ b/SymbioticTS.Build/SymbioticTS.Build.csproj
@@ -1,0 +1,59 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <!-- Pack settings -->
+  <PropertyGroup>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+
+    <!-- Suppresses the warnings about the package not having assemblies in lib/*/.dll.-->
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+    <NuspecFile>$(MSBuildProjectName).nuspec</NuspecFile>
+
+    <description>Enables SymbioticTS msbuild support.</description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
+
+    <!-- Marks all packages as 'local only' so they don't end up in the nuspec. -->
+    <PackageReference Update="@(PackageReference)" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SymbioticTS.Core\SymbioticTS.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="build\*" PackagePath="build\netstandard2.0\" />
+  </ItemGroup>
+
+  <!-- Initializes the Nuspec properties. -->
+  <Target Name="InitializeNuspecProps" BeforeTargets="GenerateNuspec">
+    <PropertyGroup>
+      <NuspecProperties>$(NuspecProperties);id=$(PackageId)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);description=$(description)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);owners=$(owners)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);authors=$(authors)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);tags=$(PackageTags)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);version=$(PackageVersion)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);projectUrl=$(PackageProjectUrl)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);repositoryType=$(RepositoryType)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);repositoryUrl=$(RepositoryUrl)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);outputPath=$([MSBuild]::NormalizeDirectory($(OutputPath)))</NuspecProperties>
+    </PropertyGroup>
+  </Target>
+
+  <!-- Executes /t:Publish for all target frameworks before packing. -->
+  <Target Name="PublishAll" BeforeTargets="GenerateNuspec">
+    <ItemGroup>
+      <_TargetFramework Condition="'$(TargetFrameworks)' != ''" Include="$(TargetFrameworks)" />
+      <_TargetFramework Condition="'$(TargetFramework)' != ''" Include="$(TargetFramework)" />
+    </ItemGroup>
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Publish" Properties="TargetFramework=%(_TargetFramework.Identity)" />
+  </Target>
+
+</Project>

--- a/SymbioticTS.Build/SymbioticTS.Build.nuspec
+++ b/SymbioticTS.Build/SymbioticTS.Build.nuspec
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <authors>$authors$</authors>
+    <description>$description$</description>
+    <projectUrl>$projectUrl$</projectUrl>
+    <tags>$tags$</tags>
+    <repository type="$repositoryType$" url="$repositoryUrl$" />
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <dependencies>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="SymbioticTS.Abstractions" version="$version$" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="lib\**\*" target="lib/" />
+    <file src="build\**\*" target="build/" />
+
+    <file src="$outputPath$\publish\**\*" target="tasks/netstandard2.0/" />
+  </files>
+</package>

--- a/SymbioticTS.Build/SymbioticTSTransformTask.cs
+++ b/SymbioticTS.Build/SymbioticTSTransformTask.cs
@@ -1,0 +1,77 @@
+using Microsoft.Build.Framework;
+using SymbioticTS.Core;
+using SymbioticTS.Core.IOAbstractions;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using MSBuildTask = Microsoft.Build.Utilities.Task;
+
+namespace SymbioticTS.Build
+{
+    public class SymbioticTSTransformTask : MSBuildTask
+    {
+        private string _inputAssemblyPath;
+
+        private string _outputPath;
+
+        /// <summary>
+        /// Gets or sets the input assembly path.
+        /// </summary>
+        /// <exception cref="ArgumentException"></exception>
+        [Required]
+        public string InputAssemblyPath
+        {
+            get => this._inputAssemblyPath;
+            set
+            {
+                if (string.IsNullOrEmpty(value) || !File.Exists(value))
+                {
+                    throw new ArgumentException($"The specified input assembly path does not exist: {value}.");
+                }
+
+                this._inputAssemblyPath = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the output path.
+        /// </summary>
+        /// <exception cref="ArgumentException"></exception>
+        [Required]
+        public string OutputPath
+        {
+            get => this._outputPath;
+            set
+            {
+                if (string.IsNullOrEmpty(value))
+                {
+                    throw new ArgumentException($"The specified output path does not exist: {value}.");
+                }
+
+                this._outputPath = value;
+            }
+        }
+
+        public override bool Execute()
+        {
+            this.Log.LogMessage(MessageImportance.Normal, $"{nameof(SymbioticTS)}: Transforming types from {this.InputAssemblyPath} to {this.OutputPath}.");
+
+            IFileSink fileSink = new DirectoryFileSink(this.OutputPath);
+            TsSymbolWriter symbolWriter = new TsSymbolWriter(fileSink);
+            TsTypeManager typeManager = new TsTypeManager();
+
+            Assembly assembly = Assembly.LoadFrom(this.InputAssemblyPath);
+
+            IReadOnlyList<Assembly> assemblies = typeManager.DiscoverAssemblies(assembly);
+            IReadOnlyList<Type> types = typeManager.DiscoverTypes(assemblies);
+            IReadOnlyList<TsTypeSymbol> typeSymbols = typeManager.ResolveTypeSymbols(types);
+
+            this.Log.LogMessage(MessageImportance.Normal, $"{nameof(SymbioticTS)}: Found and transforming {typeSymbols.Count} types.");
+
+            symbolWriter.WriteSymbols(typeSymbols);
+
+            return true;
+        }
+    }
+}

--- a/SymbioticTS.Build/build/netstandard2.0/SymbioticTS.Build.props
+++ b/SymbioticTS.Build/build/netstandard2.0/SymbioticTS.Build.props
@@ -1,0 +1,10 @@
+<Project TreatAsLocalProperty="TaskFolder;TaskAssembly" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <TaskFolder>netstandard2.0</TaskFolder>
+    <TaskAssembly>$(MSBuildThisFileDirectory)..\..\tasks\$(TaskFolder)\SymbioticTS.Build.dll</TaskAssembly>
+
+    <SymbioticTSOutputPath Condition="'$(SymbioticTSOutputPath)' == ''">$(MSBuildProjectDirectory)\generated-ts\</SymbioticTSOutputPath>
+  </PropertyGroup>
+
+  <UsingTask TaskName="SymbioticTS.Build.SymbioticTSTransformTask" AssemblyFile="$(TaskAssembly)" />
+</Project>

--- a/SymbioticTS.Build/build/netstandard2.0/SymbioticTS.Build.targets
+++ b/SymbioticTS.Build/build/netstandard2.0/SymbioticTS.Build.targets
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+
+  <PropertyGroup>
+    <_SymbioticTSInputPath Condition="'$(SymbioticTSInputPath)' == ''">$(TargetPath)</_SymbioticTSInputPath>
+  </PropertyGroup>
+
+  <Target Name="SymbioticTSTransform" AfterTargets="Build">
+    <SymbioticTSTransformTask InputAssemblyPath="$(_SymbioticTSInputPath)" OutputPath="$(SymbioticTSOutputPath)" />
+  </Target>
+
+</Project>

--- a/SymbioticTS.Core/InternalsVisibleTo.cs
+++ b/SymbioticTS.Core/InternalsVisibleTo.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("SymbioticTS.Build")]
 [assembly: InternalsVisibleTo("SymbioticTS.Core.Tests")]
 [assembly: InternalsVisibleTo("SymbioticTS.TestLibrary")]

--- a/SymbioticTS.sln
+++ b/SymbioticTS.sln
@@ -1,4 +1,4 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.28010.2026

--- a/SymbioticTS.sln
+++ b/SymbioticTS.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.28010.2026
@@ -28,7 +28,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SymbioticTS.TestLibrary", "Tests\SymbioticTS.TestLibrary\SymbioticTS.TestLibrary.csproj", "{497F6638-5F77-4D97-97E7-A4FEC5F75252}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTestReferenceLibrary", "Tests\Reference\UnitTestReferenceLibrary\UnitTestReferenceLibrary.csproj", "{0C9E46D6-9DAD-4E45-9410-231834456A5B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnitTestReferenceLibrary", "Tests\Reference\UnitTestReferenceLibrary\UnitTestReferenceLibrary.csproj", "{0C9E46D6-9DAD-4E45-9410-231834456A5B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SymbioticTS.Build", "SymbioticTS.Build\SymbioticTS.Build.csproj", "{8E80B31C-E6A8-4D03-A6F4-6637CC8AA296}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -72,6 +74,10 @@ Global
 		{0C9E46D6-9DAD-4E45-9410-231834456A5B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0C9E46D6-9DAD-4E45-9410-231834456A5B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0C9E46D6-9DAD-4E45-9410-231834456A5B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8E80B31C-E6A8-4D03-A6F4-6637CC8AA296}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8E80B31C-E6A8-4D03-A6F4-6637CC8AA296}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8E80B31C-E6A8-4D03-A6F4-6637CC8AA296}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8E80B31C-E6A8-4D03-A6F4-6637CC8AA296}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ steps:
     version: $(dotnetSdkVersion)
 
 - script: dotnet build --configuration $(buildConfiguration)
-  displayName: 'dotnet build $(buildConfiguration)'
+  displayName: 'Build SymbioticTS.sln $(buildConfiguration)'
 
 - task: DotNetCoreCLI@2
   displayName: dotnet test $(buildConfiguration)
@@ -26,3 +26,6 @@ steps:
     projects: '**/*.Tests.csproj'
     publishTestResults: true
     arguments: '--no-build --no-restore -c $(buildConfiguration)'
+
+- script: dotnet build Example\Example.sln --configuration $(buildConfiguration)
+  displayName: 'Build Example.sln $(buildConfiguration)'


### PR DESCRIPTION
### SymbioticTS.Build
- Added the SymbioticTS.Build project
  - This project will be used to hook up the type transformation to the build.
- Added an Example project that consumes the Build project
- Updated the README
- Updated build definition to include the Example

### General fixes
- Consolidated project dependency version locations
  - Declare the Nerdbank.GitVersioning version with the other dependencies
- Make sure a default configuration is set
  - This was preventing the build artifacts from being properly divided subfoldered by configuration.
- Set a common package description.