### PR TITLE
Enable warnings as errors on build machines

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,6 +20,11 @@
 
     <LangVersion>Latest</LangVersion>
 
+    <MSBuildTreatWarningsAsErrors>false</MSBuildTreatWarningsAsErrors>
+    <MSBuildTreatWarningsAsErrors Condition="'$(AGENT_ID)' != ''">true</MSBuildTreatWarningsAsErrors>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors Condition="'$(AGENT_ID)' != ''">true</TreatWarningsAsErrors>
+
     <authors>Craig Treasure</authors>
     <owners>craigktreasure</owners>
     <description>A package supporting SymbioticTS.</description>


### PR DESCRIPTION
- This change sets both the TreatWarningsAsErrors and MSBuildTreatWarningsAsErrors MSBuild properties when appropriate when the AGENT_ID variable is set indicating a build agent.