### PR TITLE
Remove dependencies from SymbioticTS.Build package

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.exclude": {
+        "__*": true
+    },
+    "omnisharp.defaultLaunchSolution": "SymbioticTS.sln"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,24 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "args": [
+                "build",
+                "SymbioticTS.sln"
+            ],
+            "type": "shell",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/SymbioticTS.Build/SymbioticTS.Build.nuspec
+++ b/SymbioticTS.Build/SymbioticTS.Build.nuspec
@@ -9,11 +9,7 @@
     <tags>$tags$</tags>
     <repository type="$repositoryType$" url="$repositoryUrl$" />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <dependencies>
-      <group targetFramework=".NETStandard2.0">
-        <dependency id="SymbioticTS.Abstractions" version="$version$" exclude="Build,Analyzers" />
-      </group>
-    </dependencies>
+    <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
     <file src="lib\**\*" target="lib/" />


### PR DESCRIPTION
  - The Build package should be able to be marked as private indicating that it should never be exposed as a runtime dependency, just a build dependency and not have that affect the SymbioticTS.Abstractions dependency.
  - This also marks the package as a `developmentDependency`.
  - This change fixes #15.