### PR TITLE
Converted the CLI project into the SymbioticTS.MSBuild package

### DIFF
--- a/Example/Example.Library/Example.Library.csproj
+++ b/Example/Example.Library/Example.Library.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SymbioticTS.Build" Version="0.1-*" PrivateAssets="All" />
+    <PackageReference Include="SymbioticTS.MSBuild" Version="0.1-*" PrivateAssets="All" />
     <PackageReference Include="SymbioticTS.Abstractions" Version="0.1-*" />
   </ItemGroup>
 

--- a/Example/Example.WebApplication/Example.WebApplication.csproj
+++ b/Example/Example.WebApplication/Example.WebApplication.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.1" />
-    <PackageReference Include="SymbioticTS.Build" Version="0.1-*" PrivateAssets="All" />
+    <PackageReference Include="SymbioticTS.MSBuild" Version="0.1-*" PrivateAssets="All" />
     <PackageReference Include="SymbioticTS.Abstractions" Version="0.1-*" />
   </ItemGroup>
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ The project is currently in what I would consider early beta status.
 |  | Status |
 | ---- | ---- |
 | Build | [![Build Status](https://treasure.visualstudio.com/SymbioticTS/_apis/build/status/SymbioticTS-CI)](https://treasure.visualstudio.com/SymbioticTS/_build/latest?definitionId=15) |
-| SymbioticTS.Abstractions | [![SymbioticTS.Abstractions](https://img.shields.io/nuget/vpre/SymbioticTS.Abstractions.svg?style=for-the-badge)](https://www.nuget.org/packages/SymbioticTS.Abstractions) |
-| SymbioticTS.Build | [![SymbioticTS.Build](https://img.shields.io/nuget/vpre/SymbioticTS.Build.svg?style=for-the-badge)](https://www.nuget.org/packages/SymbioticTS.Build) |
+| SymbioticTS.Abstractions | [![SymbioticTS.Abstractions](https://img.shields.io/nuget/vpre/SymbioticTS.Abstractions.svg)](https://www.nuget.org/packages/SymbioticTS.Abstractions) |
+| SymbioticTS.MSBuild | [![SymbioticTS.MSBuild](https://img.shields.io/nuget/vpre/SymbioticTS.MSBuild.svg)](https://www.nuget.org/packages/SymbioticTS.MSBuild) |
 
 ## Goals
 
@@ -36,13 +36,11 @@ As you pass objects to a frontend, you lose some type fidelity due to the json s
 
 ## Workflow
 
-* Add the SymbioticTS.Build NuGet package to a project.
-* Configure output location using the `SymbioticTSOutputPath` MSBuild property.
+* Add the `SymbioticTS.Abstractions` NuGet package to a project.
 * Attribute a class with `TsDto` or `TsClass` or an interface with `TsInterface`.
+* Add the `SymbioticTS.MSBuild` NuGet package to the project to hook up MSBuild integration.
+* Configure output location using the `SymbioticTSOutputPath` MSBuild property.
 * Build
-  * Discovers the full closure of the built assembly dependencies (excluding .NET assemblies).
-  * Discover public or internal attributed classes and interfaces.
-  * Generate TypeScript objects for attributed and supporting .NET objects.
 
 ## Examples
 

--- a/SymbioticTS.Build/SymbioticTS.Build.csproj
+++ b/SymbioticTS.Build/SymbioticTS.Build.csproj
@@ -6,7 +6,8 @@
 
   <!-- Pack settings -->
   <PropertyGroup>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <!-- Disabled until we can properly support assembly isolation with unloading in .NET Core 3. -->
+    <!-- <GeneratePackageOnBuild>true</GeneratePackageOnBuild> -->
 
     <!-- Suppresses the warnings about the package not having assemblies in lib/*/.dll.-->
     <NoPackageAnalysis>true</NoPackageAnalysis>

--- a/SymbioticTS.Cli/Program.cs
+++ b/SymbioticTS.Cli/Program.cs
@@ -28,11 +28,14 @@ namespace SymbioticTS.Cli
 
             transformer.Transform(options.InputAssemblyPath, options.OutputPath, transformerOptions, out IReadOnlyCollection<string> filesCreated);
 
-            Console.WriteLine($"Transformed {filesCreated.Count} objects to {options.OutputPath}:");
-
-            foreach (string file in filesCreated)
+            if (!options.Silent)
             {
-                Console.WriteLine($"    {file}");
+                Console.WriteLine($"Transformed {filesCreated.Count} objects to {options.OutputPath}:");
+
+                foreach (string file in filesCreated)
+                {
+                    Console.WriteLine($"    {file}");
+                }
             }
         }
     }

--- a/SymbioticTS.Cli/ProgramOptions.cs
+++ b/SymbioticTS.Cli/ProgramOptions.cs
@@ -21,5 +21,11 @@ namespace SymbioticTS.Cli
         /// </summary>
         [Option('o', "output", Required = true, HelpText = "The path to write the transfomed objects.")]
         public string OutputPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether output is silent.
+        /// </summary>
+        [Option("silent", HelpText = "Omit console output except for errors.")]
+        public bool Silent { get; set; }
     }
 }

--- a/SymbioticTS.Cli/SymbioticTS.Cli.csproj
+++ b/SymbioticTS.Cli/SymbioticTS.Cli.csproj
@@ -5,6 +5,23 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
+  <!-- Pack settings -->
+  <PropertyGroup>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+
+    <!-- Suppresses the warnings about the package not having assemblies in lib/*/.dll.-->
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+    <NuspecFile>$(MSBuildProjectName).nuspec</NuspecFile>
+
+    <PackageId>SymbioticTS.MSBuild</PackageId>
+    <description>Enables SymbioticTS MSBuild support.</description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Marks all packages as 'local only' so they don't end up in the nuspec. -->
+    <PackageReference Update="@(PackageReference)" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.3.0" />
   </ItemGroup>
@@ -12,5 +29,34 @@
   <ItemGroup>
     <ProjectReference Include="..\SymbioticTS.Core\SymbioticTS.Core.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="build\*" PackagePath="build\netstandard2.0\" />
+  </ItemGroup>
+
+  <!-- Initializes the Nuspec properties. -->
+  <Target Name="InitializeNuspecProps" BeforeTargets="GenerateNuspec">
+    <PropertyGroup>
+      <NuspecProperties>$(NuspecProperties);id=$(PackageId)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);description=$(description)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);owners=$(owners)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);authors=$(authors)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);tags=$(PackageTags)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);version=$(PackageVersion)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);projectUrl=$(PackageProjectUrl)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);repositoryType=$(RepositoryType)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);repositoryUrl=$(RepositoryUrl)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);outputPath=$([MSBuild]::NormalizeDirectory($(OutputPath)))</NuspecProperties>
+    </PropertyGroup>
+  </Target>
+
+  <!-- Executes /t:Publish for all target frameworks before packing. -->
+  <Target Name="PublishAll" BeforeTargets="GenerateNuspec">
+    <ItemGroup>
+      <_TargetFramework Condition="'$(TargetFrameworks)' != ''" Include="$(TargetFrameworks)" />
+      <_TargetFramework Condition="'$(TargetFramework)' != ''" Include="$(TargetFramework)" />
+    </ItemGroup>
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Publish" Properties="TargetFramework=%(_TargetFramework.Identity)" />
+  </Target>
 
 </Project>

--- a/SymbioticTS.Cli/SymbioticTS.Cli.nuspec
+++ b/SymbioticTS.Cli/SymbioticTS.Cli.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <authors>$authors$</authors>
+    <description>$description$</description>
+    <projectUrl>$projectUrl$</projectUrl>
+    <tags>$tags$</tags>
+    <repository type="$repositoryType$" url="$repositoryUrl$" />
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <developmentDependency>true</developmentDependency>
+  </metadata>
+  <files>
+    <file src="lib\**\*" target="lib/" />
+    <file src="build\**\*" target="build/" />
+
+    <file src="$outputPath$\publish\**\*" target="tools/netcoreapp2.1/" />
+  </files>
+</package>

--- a/SymbioticTS.Cli/build/netstandard2.0/SymbioticTS.MSBuild.props
+++ b/SymbioticTS.Cli/build/netstandard2.0/SymbioticTS.MSBuild.props
@@ -1,0 +1,8 @@
+<Project TreatAsLocalProperty="FrameworkFolder" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <FrameworkFolder>netcoreapp2.1</FrameworkFolder>
+
+    <SymbioticTSExe>dotnet "$(MSBuildThisFileDirectory)..\..\tools\$(FrameworkFolder)\SymbioticTS.Cli.dll"</SymbioticTSExe>
+    <SymbioticTSOutputPath Condition="'$(SymbioticTSOutputPath)' == ''">$(MSBuildProjectDirectory)\generated-ts\</SymbioticTSOutputPath>
+  </PropertyGroup>
+</Project>

--- a/SymbioticTS.Cli/build/netstandard2.0/SymbioticTS.MSBuild.targets
+++ b/SymbioticTS.Cli/build/netstandard2.0/SymbioticTS.MSBuild.targets
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+
+  <PropertyGroup>
+    <_SymbioticTSInputPath Condition="'$(SymbioticTSInputPath)' == ''">$(TargetPath)</_SymbioticTSInputPath>
+  </PropertyGroup>
+
+  <Target Name="SymbioticTSWriteAssemblyReferences" AfterTargets="ResolveAssemblyReferences">
+    <PropertyGroup>
+      <_SymbioticTSAssemblyReferencesFilePath>$(IntermediateOutputPath)resolved-references.txt</_SymbioticTSAssemblyReferencesFilePath>
+    </PropertyGroup>
+
+    <WriteLinesToFile Lines="@(_ResolveAssemblyReferenceResolvedFiles)" File="$(_SymbioticTSAssemblyReferencesFilePath)" Overwrite="true" />
+  </Target>
+
+  <Target Name="SymbioticTSTransform" AfterTargets="Build">
+    <PropertyGroup>
+      <_SymbioticTSTransformArguments>--input "$(_SymbioticTSInputPath)"</_SymbioticTSTransformArguments>
+      <_SymbioticTSTransformArguments>$(_SymbioticTSTransformArguments) --output "$(SymbioticTSOutputPath.TrimEnd('\'))"</_SymbioticTSTransformArguments>
+      <_SymbioticTSTransformArguments>$(_SymbioticTSTransformArguments) --assembly-references-file "$(_SymbioticTSAssemblyReferencesFilePath)"</_SymbioticTSTransformArguments>
+      <_SymbioticTSTransformArguments>$(_SymbioticTSTransformArguments) --silent</_SymbioticTSTransformArguments>
+    </PropertyGroup>
+
+    <Exec Command="$(SymbioticTSExe) $(_SymbioticTSTransformArguments)" />
+  </Target>
+
+</Project>


### PR DESCRIPTION
### Converted the CLI project into the SymbioticTS.MSBuild package

While the SymbioticTS.Build package, which includes an MSBuild task, is great, it falls apart due to MSBuild node reuse, which was enabled by default at some point in the last few years. This keeps the process alive; including the file handles on assemblies that were loaded, which prevents us from being able to build again due to locked files. There is currently no way to unload assemblies once loaded. This is supposed to be supported in .NET Core 3.0, but we'd also need it in a version of netstandard supported by MSBuild.

As a workaround, I am repurposing the CLI which will run using the `Exec` task and terminate releasing all handles.

The new SymbioticTS.MSBuild package will now be the preferred method for hooking up MSBuild integration until the SymbioticTS.Build package can be supported correctly.