### PR TITLE
Avoid DTO interface name collisions

### DIFF
--- a/Tests/Reference/UnitTestReferenceLibrary/WithOverlap/Circle.cs
+++ b/Tests/Reference/UnitTestReferenceLibrary/WithOverlap/Circle.cs
@@ -1,0 +1,15 @@
+using SymbioticTS.Abstractions;
+
+namespace UnitTestReferenceLibrary.WithOverlap
+{
+    [TsDto]
+    public class Circle : ICircle
+    {
+        public double Diameter { get; }
+    }
+
+    public interface ICircle
+    {
+        double Diameter { get; }
+    }
+}

--- a/Tests/SymbioticTS.Core.Tests/TsTypeManagerTests.cs
+++ b/Tests/SymbioticTS.Core.Tests/TsTypeManagerTests.cs
@@ -135,6 +135,30 @@ namespace SymbioticTS.Core.Tests
             ValidateDiscoveryReferenceProject(actualTypes);
         }
 
+        [Fact]
+        public void ResolveTypeSymbolsWithPotentialDtoNameCollision()
+        {
+            TsTypeManager manager = new TsTypeManager();
+
+            IReadOnlyList<Type> discoveredTypes = new[]
+            {
+                typeof(UnitTestReferenceLibrary.WithOverlap.Circle),
+                typeof(UnitTestReferenceLibrary.WithOverlap.ICircle),
+            };
+
+            IReadOnlyList<TsTypeSymbol> symbols = manager.ResolveTypeSymbols(discoveredTypes);
+
+            Assert.Equal(4, symbols.Count);
+
+            Assert.Equal(new[]
+            {
+                "Circle",
+                "ICircle",
+                "ICircleDto",
+                "ICircleDto1",
+            }, symbols.Select(x => x.Name).OrderBy(x => x));
+        }
+
         private static void ValidateDiscoveryReferenceProject(IReadOnlyList<Type> actualTypes)
         {
             Assert.NotNull(actualTypes);


### PR DESCRIPTION
There was an issue with name collisions when generating the DTO interface names. While I'm not crazy about the workaround, it resolves the issue. Name collisions are resolved by appending an incrementing number to the name.