### PR TITLE
Correctly disable tslint rules in a file

### DIFF
--- a/SymbioticTS.Core/TsSymbolWriter.cs
+++ b/SymbioticTS.Core/TsSymbolWriter.cs
@@ -450,7 +450,7 @@ namespace SymbioticTS.Core
         private void WriteTsLintFileRules(SourceWriter writer)
         {
             writer
-                .WriteLine("// tslint:disable:max-line-length")
+                .WriteLine("/* tslint:disable:max-line-length */")
                 .WriteLine();
         }
     }

--- a/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/AnnotatedClass.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/AnnotatedClass.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 export class AnnotatedClass {
     public property: boolean;

--- a/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/AnnotatedEnum.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/AnnotatedEnum.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 export enum AnnotatedEnum {
     Value = 0,

--- a/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/ClassWithNetFrameworkProperties.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/ClassWithNetFrameworkProperties.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 export class ClassWithNetFrameworkProperties {
     public dateTimeProperty: Date;

--- a/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/ClassWithUnannotatedArrayClassProperty.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/ClassWithUnannotatedArrayClassProperty.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { UnnanotatedArrayClass } from './UnnanotatedArrayClass';
 

--- a/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/ClassWithUnannotatedBase.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/ClassWithUnannotatedBase.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { ClassWithUnannotatedBaseBase } from './ClassWithUnannotatedBaseBase';
 

--- a/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/ClassWithUnannotatedBaseBase.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/ClassWithUnannotatedBaseBase.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 export abstract class ClassWithUnannotatedBaseBase {
 }

--- a/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/ClassWithUnannotatedGenericProperties.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/ClassWithUnannotatedGenericProperties.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { UnnanotatedGenericClass } from './UnnanotatedGenericClass';
 import { UnnanotatedNullableGenericStruct } from './UnnanotatedNullableGenericStruct';

--- a/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/ClassWithUnannotatedInterface.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/ClassWithUnannotatedInterface.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { ClassWithUnannotatedInterfaceInterface } from './ClassWithUnannotatedInterfaceInterface';
 

--- a/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/ClassWithUnannotatedInterfaceInterface.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/ClassWithUnannotatedInterfaceInterface.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 // tslint:disable-next-line:interface-name no-empty-interface
 export interface ClassWithUnannotatedInterfaceInterface {

--- a/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/ClassWithUnannotatedInterfaceProperties.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/ClassWithUnannotatedInterfaceProperties.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { ClassWithUnannotatedInterfacePropertiesInterface } from './ClassWithUnannotatedInterfacePropertiesInterface';
 import { IUnannotatedInterface } from './IUnannotatedInterface';

--- a/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/ClassWithUnannotatedInterfacePropertiesInterface.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/ClassWithUnannotatedInterfacePropertiesInterface.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { IUnannotatedInterface } from './IUnannotatedInterface';
 import { UnannotatedClass } from './UnannotatedClass';

--- a/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/ClassWithUnannotatedNestedProperties.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/ClassWithUnannotatedNestedProperties.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { UnannotatedClass } from './UnannotatedClass';
 

--- a/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/ClassWithUnannotatedProperties.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/ClassWithUnannotatedProperties.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { IUnannotatedInterface } from './IUnannotatedInterface';
 import { UnannotatedClass } from './UnannotatedClass';

--- a/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/IAnnotatedInterface.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/IAnnotatedInterface.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 export interface IAnnotatedInterface {
     readonly property: boolean;

--- a/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/IUnannotatedInterface.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/IUnannotatedInterface.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 // tslint:disable-next-line:no-empty-interface
 export interface IUnannotatedInterface {

--- a/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/IUnannotatedPropertyInterface.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/IUnannotatedPropertyInterface.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 // tslint:disable-next-line:no-empty-interface
 export interface IUnannotatedPropertyInterface {

--- a/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/InterfaceWithUnannotatedInterface.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/InterfaceWithUnannotatedInterface.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { InterfaceWithUnannotatedInterfaceInterface } from './InterfaceWithUnannotatedInterfaceInterface';
 

--- a/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/InterfaceWithUnannotatedInterfaceInterface.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/InterfaceWithUnannotatedInterfaceInterface.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 // tslint:disable-next-line:no-empty-interface
 export interface InterfaceWithUnannotatedInterfaceInterface {

--- a/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/UnannotatedClass.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/UnannotatedClass.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 export class UnannotatedClass {
 }

--- a/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/UnannotatedEnum.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/UnannotatedEnum.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 export enum UnannotatedEnum {
 }

--- a/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/UnannotatedPropertyClass.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/UnannotatedPropertyClass.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 export class UnannotatedPropertyClass {
 }

--- a/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/UnannotatedPropertyEnum.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/UnannotatedPropertyEnum.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 export enum UnannotatedPropertyEnum {
 }

--- a/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/UnnanotatedArrayClass.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/UnnanotatedArrayClass.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 export class UnnanotatedArrayClass {
 }

--- a/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/UnnanotatedGenericClass.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/UnnanotatedGenericClass.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 export class UnnanotatedGenericClass {
 }

--- a/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/UnnanotatedNullableGenericStruct.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/DiscoveryReferenceProject/UnnanotatedNullableGenericStruct.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 export class UnnanotatedNullableGenericStruct {
 }

--- a/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/BaseShape.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/BaseShape.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { Color } from './Color';
 import { IShape } from './IShape';

--- a/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/Circle.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/Circle.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { BaseShape } from './BaseShape';
 import { Color } from './Color';

--- a/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/Color.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/Color.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 export enum Color {
     Blue = 0,

--- a/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/IBaseShapeDto.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/IBaseShapeDto.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { IShapeDto } from './IShapeDto';
 

--- a/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/ICircleDto.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/ICircleDto.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { IBaseShapeDto } from './IBaseShapeDto';
 import { IShapeDto } from './IShapeDto';

--- a/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/IQuadrilateral.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/IQuadrilateral.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 // tslint:disable-next-line:no-empty-interface
 export interface IQuadrilateral {

--- a/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/IQuadrilateralDto.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/IQuadrilateralDto.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 // tslint:disable-next-line:no-empty-interface
 export interface IQuadrilateralDto {

--- a/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/IRectangleDto.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/IRectangleDto.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { IBaseShapeDto } from './IBaseShapeDto';
 import { IQuadrilateralDto } from './IQuadrilateralDto';

--- a/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/IShape.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/IShape.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { Color } from './Color';
 import { ShapeBorder } from './ShapeBorder';

--- a/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/IShapeDto.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/IShapeDto.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { Color } from './Color';
 import { ShapeBorder } from './ShapeBorder';

--- a/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/IShapeViewModelDto.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/IShapeViewModelDto.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { ICircleDto } from './ICircleDto';
 import { IRectangleDto } from './IRectangleDto';

--- a/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/IViewModelBaseDto.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/IViewModelBaseDto.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 export interface IViewModelBaseDto {
     dateCreated: string;

--- a/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/Rectangle.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/Rectangle.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { BaseShape } from './BaseShape';
 import { Color } from './Color';

--- a/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/ShapeBorder.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/ShapeBorder.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 export enum ShapeBorder {
     None = 0,

--- a/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/ShapeViewModel.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/ShapeViewModel.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { Circle } from './Circle';
 import { IShape } from './IShape';

--- a/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/Triangle.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/Triangle.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { Color } from './Color';
 import { ShapeBorder } from './ShapeBorder';

--- a/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/ViewModelBase.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/ReferenceProject/ViewModelBase.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 export abstract class ViewModelBase {
     public dateCreated: Date;

--- a/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoSimpleTestClass/DtoSimpleTestClass.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoSimpleTestClass/DtoSimpleTestClass.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { IDtoSimpleTestClassDto } from './IDtoSimpleTestClassDto';
 

--- a/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoSimpleTestClass/IDtoSimpleTestClassDto.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoSimpleTestClass/IDtoSimpleTestClassDto.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 export interface IDtoSimpleTestClassDto {
     count: number;

--- a/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithDateTimeCollectionTestClass/DtoWithDateTimeCollectionTestClass.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithDateTimeCollectionTestClass/DtoWithDateTimeCollectionTestClass.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { IDtoWithDateTimeCollectionTestClassDto } from './IDtoWithDateTimeCollectionTestClassDto';
 

--- a/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithDateTimeCollectionTestClass/IDtoWithDateTimeCollectionTestClassDto.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithDateTimeCollectionTestClass/IDtoWithDateTimeCollectionTestClassDto.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 export interface IDtoWithDateTimeCollectionTestClassDto {
     count: number;

--- a/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithDateTimeTestClass/DtoWithDateTimeTestClass.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithDateTimeTestClass/DtoWithDateTimeTestClass.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { IDtoWithDateTimeTestClassDto } from './IDtoWithDateTimeTestClassDto';
 

--- a/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithDateTimeTestClass/IDtoWithDateTimeTestClassDto.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithDateTimeTestClass/IDtoWithDateTimeTestClassDto.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 export interface IDtoWithDateTimeTestClassDto {
     count: number;

--- a/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithOptionalPropertyTestClass/DtoWithOptionalPropertyTestClass.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithOptionalPropertyTestClass/DtoWithOptionalPropertyTestClass.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { IDtoWithOptionalPropertyTestClassDto } from './IDtoWithOptionalPropertyTestClassDto';
 

--- a/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithOptionalPropertyTestClass/IDtoWithOptionalPropertyTestClassDto.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithOptionalPropertyTestClass/IDtoWithOptionalPropertyTestClassDto.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 export interface IDtoWithOptionalPropertyTestClassDto {
     readonly count?: number;

--- a/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithReadOnlyPropertyTestClass/DtoWithReadOnlyPropertyTestClass.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithReadOnlyPropertyTestClass/DtoWithReadOnlyPropertyTestClass.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { IDtoWithReadOnlyPropertyTestClassDto } from './IDtoWithReadOnlyPropertyTestClassDto';
 

--- a/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithReadOnlyPropertyTestClass/IDtoWithReadOnlyPropertyTestClassDto.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithReadOnlyPropertyTestClass/IDtoWithReadOnlyPropertyTestClassDto.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 export interface IDtoWithReadOnlyPropertyTestClassDto {
     readonly count: number;

--- a/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformClassCollectionProperty/ClassRequiresTransform.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformClassCollectionProperty/ClassRequiresTransform.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { IClassRequiresTransformDto } from './IClassRequiresTransformDto';
 

--- a/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformClassCollectionProperty/DtoWithTransformClassCollectionProperty.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformClassCollectionProperty/DtoWithTransformClassCollectionProperty.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { ClassRequiresTransform } from './ClassRequiresTransform';
 import { IDtoWithTransformClassCollectionPropertyDto } from './IDtoWithTransformClassCollectionPropertyDto';

--- a/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformClassCollectionProperty/IClassRequiresTransformDto.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformClassCollectionProperty/IClassRequiresTransformDto.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 export interface IClassRequiresTransformDto {
     birthdate: string;

--- a/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformClassCollectionProperty/IDtoWithTransformClassCollectionPropertyDto.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformClassCollectionProperty/IDtoWithTransformClassCollectionPropertyDto.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { IClassRequiresTransformDto } from './IClassRequiresTransformDto';
 

--- a/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformClassProperty/ClassRequiresTransform.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformClassProperty/ClassRequiresTransform.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { IClassRequiresTransformDto } from './IClassRequiresTransformDto';
 

--- a/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformClassProperty/DtoWithTransformClassProperty.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformClassProperty/DtoWithTransformClassProperty.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { ClassRequiresTransform } from './ClassRequiresTransform';
 import { IDtoWithTransformClassPropertyDto } from './IDtoWithTransformClassPropertyDto';

--- a/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformClassProperty/IClassRequiresTransformDto.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformClassProperty/IClassRequiresTransformDto.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 export interface IClassRequiresTransformDto {
     birthdate: string;

--- a/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformClassProperty/IDtoWithTransformClassPropertyDto.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformClassProperty/IDtoWithTransformClassPropertyDto.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { IClassRequiresTransformDto } from './IClassRequiresTransformDto';
 

--- a/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformInterfaceCollectionProperty/DtoWithTransformInterfaceCollectionProperty.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformInterfaceCollectionProperty/DtoWithTransformInterfaceCollectionProperty.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { IDtoWithTransformInterfaceCollectionPropertyDto } from './IDtoWithTransformInterfaceCollectionPropertyDto';
 import { IRequireTransform } from './IRequireTransform';

--- a/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformInterfaceCollectionProperty/IDtoWithTransformInterfaceCollectionPropertyDto.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformInterfaceCollectionProperty/IDtoWithTransformInterfaceCollectionPropertyDto.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { IRequireTransformDto } from './IRequireTransformDto';
 

--- a/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformInterfaceCollectionProperty/IRequireTransform.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformInterfaceCollectionProperty/IRequireTransform.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 export interface IRequireTransform {
     readonly birthdate: Date;

--- a/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformInterfaceCollectionProperty/IRequireTransformDto.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformInterfaceCollectionProperty/IRequireTransformDto.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 export interface IRequireTransformDto {
     readonly birthdate: string;

--- a/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformInterfaceProperty/DtoWithTransformInterfaceProperty.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformInterfaceProperty/DtoWithTransformInterfaceProperty.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { IDtoWithTransformInterfacePropertyDto } from './IDtoWithTransformInterfacePropertyDto';
 import { IRequireTransform } from './IRequireTransform';

--- a/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformInterfaceProperty/IDtoWithTransformInterfacePropertyDto.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformInterfaceProperty/IDtoWithTransformInterfacePropertyDto.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 import { IRequireTransformDto } from './IRequireTransformDto';
 

--- a/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformInterfaceProperty/IRequireTransform.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformInterfaceProperty/IRequireTransform.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 export interface IRequireTransform {
     readonly birthdate: Date;

--- a/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformInterfaceProperty/IRequireTransformDto.ts
+++ b/Tests/SymbioticTS.Core.Tests/Content/UnitTests/DtoWithTransformInterfaceProperty/IRequireTransformDto.ts
@@ -3,7 +3,7 @@
  * All changes will be lost the next time the file is generated.
  */
 
-// tslint:disable:max-line-length
+/* tslint:disable:max-line-length */
 
 export interface IRequireTransformDto {
     readonly birthdate: string;


### PR DESCRIPTION
  - This change causes us to emit tslint rule flags for files properly according to https://palantir.github.io/tslint/usage/rule-flags/.